### PR TITLE
[ddev-cfg] Add ddev config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,6 @@
+APIVersion: "1"
+name: drupal8
+type: drupal8
+docroot: docroot
+webimage: drud/nginx-php-fpm7-local:v0.3.0
+dbimage: drud/mysql-docker-local-57:v0.2.0


### PR DESCRIPTION
We need a ddev config for testing the local plugin in tests.

We could just generate this via the `ddevapp` package, but it'd be nice if it was shipped ahead of time so that we can also use this as a demo repo.

## Followup required
- [ ] Tag 0.2.0 in this repo