### PR TITLE
Remove 'name' from config.yaml so test instances can have unique names

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
 APIVersion: "1"
-name: drupal8
 type: drupal8
 docroot: docroot


### PR DESCRIPTION
This repo is used for testing, and in https://github.com/drud/ddev/pull/166 @tannerjfco made it possible to have default site/app 'name', making 'name' optional. 

The PR removes 'name' so that the tests over there can have different names for the site depending on the test underway.